### PR TITLE
[FEATURE] 폴더 삭제시 회고를 삭제하도록 변경

### DIFF
--- a/src/main/java/com/careerpirates/resumate/review/infrastructure/ReviewRepository.java
+++ b/src/main/java/com/careerpirates/resumate/review/infrastructure/ReviewRepository.java
@@ -7,9 +7,12 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    List<Review> findByFolder(Folder folder);
 
     Optional<Review> findByIdAndIsDeletedFalse(long id);
 


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #30

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
- 폴더 삭제시 회고를 삭제하도록 변경

## 📸스크린샷 (선택)

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
없음

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 폴더 및 하위 폴더를 삭제하면 해당 폴더에 연결된 회고가 함께 소프트 삭제되도록 처리했습니다. 폴더 삭제 후에도 회고가 목록에 남아 보이던 문제를 방지하며, 데이터 일관성을 높입니다.
  - 이제 사용자는 폴더를 삭제하면 관련 회고가 목록과 검색 결과에서 더 이상 표시되지 않습니다.
- 테스트
  - 폴더 삭제 시 회고 연동 삭제 동작을 검증하는 통합 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->