### PR TITLE
[FEATURE] 폴더 목록 조회 조건 추가

### DIFF
--- a/src/main/java/com/careerpirates/resumate/folder/application/dto/response/FolderTreeResponse.java
+++ b/src/main/java/com/careerpirates/resumate/folder/application/dto/response/FolderTreeResponse.java
@@ -20,7 +20,7 @@ public class FolderTreeResponse {
     private LocalDateTime modifiedAt;
     private List<FolderTreeResponse> children;
 
-    public static FolderTreeResponse of(Folder folder) {
+    public static FolderTreeResponse of(Folder folder, boolean children) {
         Folder parent = folder.getParent();
 
         return FolderTreeResponse.builder()
@@ -30,10 +30,12 @@ public class FolderTreeResponse {
                 .modifiedAt(folder.getModifiedAt())
                 .parentId(parent == null ? null : parent.getId())
                 .parentName(parent == null ? null : parent.getName())
-                .children(folder.getChildren().stream()
-                        .sorted(Comparator.comparingInt(Folder::getOrder))
-                        .map(FolderTreeResponse::of)
-                        .toList()
+                .children(children
+                        ? folder.getChildren().stream()
+                            .sorted(Comparator.comparingInt(Folder::getOrder))
+                            .map(fd -> FolderTreeResponse.of(fd, children))
+                            .toList()
+                        : null
                 )
                 .build();
     }

--- a/src/main/java/com/careerpirates/resumate/folder/docs/FolderControllerDocs.java
+++ b/src/main/java/com/careerpirates/resumate/folder/docs/FolderControllerDocs.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
@@ -57,7 +58,8 @@ public interface FolderControllerDocs {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "폴더 목록 조회에 성공하였습니다."),
     })
-    SuccessResponse<List<FolderTreeResponse>> getFolders();
+    SuccessResponse<List<FolderTreeResponse>> getFolders(@RequestParam(required = false) Long parentId,
+                                                         @RequestParam(defaultValue = "true") Boolean children);
 
     @Operation(method = "PATCH", summary = "상위 폴더 순서 설정", description = "상위 폴더들 사이의 순서를 설정합니다.")
     @ApiResponses(value = {

--- a/src/main/java/com/careerpirates/resumate/folder/infrastructure/FolderRepository.java
+++ b/src/main/java/com/careerpirates/resumate/folder/infrastructure/FolderRepository.java
@@ -12,6 +12,9 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     @Query("SELECT fd from Folder fd WHERE fd.parent IS NULL ORDER BY fd.order")
     List<Folder> findParentFolders();
 
+    @Query("SELECT fd from Folder fd WHERE fd.parent = :parent ORDER BY fd.order")
+    List<Folder> findChildFolders(Folder parent);
+
     List<Folder> findByIdIn(List<Long> ids);
 
     Optional<Folder> findByName(String name);

--- a/src/main/java/com/careerpirates/resumate/folder/presentation/FolderController.java
+++ b/src/main/java/com/careerpirates/resumate/folder/presentation/FolderController.java
@@ -44,8 +44,9 @@ public class FolderController implements FolderControllerDocs {
     }
 
     @GetMapping
-    public SuccessResponse<List<FolderTreeResponse>> getFolders() {
-        List<FolderTreeResponse> response = folderService.getFolders();
+    public SuccessResponse<List<FolderTreeResponse>> getFolders(@RequestParam(required = false) Long parentId,
+                                                                @RequestParam(defaultValue = "true") Boolean children) {
+        List<FolderTreeResponse> response = folderService.getFolders(parentId, children);
         return SuccessResponse.of(FolderSuccess.GET_FOLDERS, response);
     }
 

--- a/src/test/java/com/careerpirates/resumate/folder/application/service/FolderServiceTest.java
+++ b/src/test/java/com/careerpirates/resumate/folder/application/service/FolderServiceTest.java
@@ -167,7 +167,7 @@ class FolderServiceTest {
     @DisplayName("상위 폴더와 하위 폴더 목록을 조회합니다.")
     void getFolders_success() {
         // when
-        List<FolderTreeResponse> result = folderService.getFolders();
+        List<FolderTreeResponse> result = folderService.getFolders(null, true);
 
         // then
         assertThat(result).hasSize(2);
@@ -236,7 +236,7 @@ class FolderServiceTest {
         folderService.setSubFolderTree(folderA.getId(), request);
 
         // then
-        List<FolderTreeResponse> foundFolders = folderService.getFolders();
+        List<FolderTreeResponse> foundFolders = folderService.getFolders(null, true);;
         assertThat(childrenOf(foundFolders, "A"))
                 .extracting("name")
                 .containsExactly("BA", "AA", "AB");


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #87

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
- 폴더 목록 조회시 상위 폴더만 또는 하위 폴더만 조회하는 조건을 추가

## 📸스크린샷 (선택)

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
없음

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - GET /api/folder에 선택적 쿼리 파라미터 parentId, children 추가. 특정 부모 기준으로 폴더 목록 조회 및 하위 노드 포함 여부를 토글할 수 있습니다.
  - 상위 폴더 또는 하위 폴더만 선택적으로 조회 가능.
- 문서
  - API 문서에 parentId, children 파라미터와 기본값(true) 반영.
- 테스트
  - 변경된 API 시그니처에 맞춰 단위 테스트 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->