### PR TITLE
[REFACTOR] OpenAI API 호출 Bucket4j 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 
+    // API 요청 제한
+    implementation 'com.bucket4j:bucket4j-core:8.10.1'
+
     // 모니터링
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'

--- a/src/main/java/com/careerpirates/resumate/analysis/config/OpenAIRateLimiter.java
+++ b/src/main/java/com/careerpirates/resumate/analysis/config/OpenAIRateLimiter.java
@@ -1,0 +1,26 @@
+package com.careerpirates.resumate.analysis.config;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+public class OpenAIRateLimiter {
+
+    private final Bucket bucket;
+
+    public OpenAIRateLimiter() {
+        Bandwidth limit = Bandwidth.builder()
+                .capacity(5)
+                .refillIntervally(5, Duration.ofMinutes(1))
+                .build();
+
+        this.bucket = Bucket.builder().addLimit(limit).build();
+    }
+
+    public boolean tryConsume() {
+        return bucket.tryConsume(1);
+    }
+}

--- a/src/main/java/com/careerpirates/resumate/analysis/message/exception/AnalysisError.java
+++ b/src/main/java/com/careerpirates/resumate/analysis/message/exception/AnalysisError.java
@@ -12,7 +12,8 @@ public enum AnalysisError implements ErrorCode {
     FOLDER_EMPTY("폴더에 저장된 회고가 없습니다.", HttpStatus.BAD_REQUEST, "AN_001"),
     ANALYSIS_NOT_FOUND("분석 객체를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "AN_002"),
     NO_FOLDER_REQUESTED("분석할 폴더 ID가 전달되지 않았습니다.", HttpStatus.BAD_REQUEST, "AN_003"),
-    ANALYSIS_REUSABLE("1분 내 분석 요청하였거나, 변경사항이 없는 폴더가 있습니다.", HttpStatus.NOT_MODIFIED, "AN_004");
+    ANALYSIS_REUSABLE("1분 내 분석 요청하였거나, 변경사항이 없는 폴더가 있습니다.", HttpStatus.NOT_MODIFIED, "AN_004"),
+    RATE_LIMIT_EXCEEDED("1분 내 OpenAI API 호출 한계에 도달하였습니다.", HttpStatus.TOO_MANY_REQUESTS, "AN_005");
 
     private final String message;
     private final HttpStatus status;

--- a/src/test/java/com/careerpirates/resumate/analysis/application/service/OpenAIServiceTest.java
+++ b/src/test/java/com/careerpirates/resumate/analysis/application/service/OpenAIServiceTest.java
@@ -28,9 +28,9 @@ class OpenAIServiceTest {
 
     @Autowired
     private OpenAIProperties properties;
-    @Autowired
-    private OpenAIRateLimiter rateLimiter;
 
+    @MockitoBean
+    private OpenAIRateLimiter rateLimiter;
     @MockitoBean
     private AnalysisService analysisService;
     @MockitoBean

--- a/src/test/java/com/careerpirates/resumate/analysis/application/service/OpenAIServiceTest.java
+++ b/src/test/java/com/careerpirates/resumate/analysis/application/service/OpenAIServiceTest.java
@@ -1,0 +1,68 @@
+package com.careerpirates.resumate.analysis.application.service;
+
+import com.careerpirates.resumate.analysis.config.OpenAIProperties;
+import com.careerpirates.resumate.analysis.config.OpenAIRateLimiter;
+import com.careerpirates.resumate.analysis.event.AnalysisErrorEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+@Transactional
+@SpringBootTest
+class OpenAIServiceTest {
+
+    OpenAIService openAIService;
+
+    @Autowired
+    private OpenAIProperties properties;
+    @Autowired
+    private OpenAIRateLimiter rateLimiter;
+
+    @MockitoBean
+    private AnalysisService analysisService;
+    @MockitoBean
+    private WebClient webClient;
+    @MockitoBean
+    private ApplicationEventPublisher eventPublisher;
+
+    @BeforeEach
+    void setUp() {
+        openAIService = new OpenAIService(
+                webClient,
+                properties,
+                rateLimiter,
+                eventPublisher
+        );
+    }
+
+    @Test
+    @DisplayName("OpenAI API 콜 제한에 도달하면 분석 실패 이벤트가 발행됩니다.")
+    void sendRequest_tooManyRequests() {
+        // given
+        while (rateLimiter.tryConsume()) { /* 소비해서 버킷 비우기 */ }
+        Long analysisId = 1L;
+
+        // when
+        openAIService.sendRequest(analysisId, "test").join();
+
+        // then
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        Object publishedEvent = captor.getValue();
+        assertInstanceOf(AnalysisErrorEvent.class, publishedEvent);
+        assertEquals(analysisId, ((AnalysisErrorEvent) publishedEvent).getAnalysisId());
+    }
+}


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #92

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
OpenAI API의 분당 호출 토큰 수 제한을 넘지 않기 위해 Bucket4j를 적용합니다.
요청마다 약 6000 토큰 정도를 사용한다 가정하여, 분당 최대 5회 API를 호출할 수 있도록 제한합니다.

## 📸스크린샷 (선택)

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
없음

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - OpenAI 분석 요청에 분 단위 레이트 리밋(기본 5회/분)을 도입했습니다. 한도 초과 시 요청이 차단되고 429 상태의 안내 메시지가 전달됩니다.
- 테스트
  - 요청 한도 초과 시 이벤트 발행 및 차단 동작을 검증하는 단위 테스트를 추가했습니다.
- 기타
  - 요청 제한을 위한 라이브러리 의존성을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->