### PR TITLE
[REFACTOR] OpenAI API 요청 처리량 확장을 위한 멀티 계정 구조 적용

### DIFF
--- a/src/main/java/com/careerpirates/resumate/analysis/config/OpenAIProperties.java
+++ b/src/main/java/com/careerpirates/resumate/analysis/config/OpenAIProperties.java
@@ -72,7 +72,7 @@ public class OpenAIProperties {
         if (this.apiKeys.isEmpty() || this.prompts.isEmpty()) {
             throw new IllegalStateException("OpenAI API 키와 프롬프트 환경변수를 설정하세요.");
         }
-        if (this.apiKey.size() != this.prompts.size()) {
+        if (this.apiKeys.size() != this.prompts.size()) {
             throw new IllegalStateException("OpenAI API 키와 프롬프트 환경변수 개수가 일치하지 않습니다.");
         }
     }

--- a/src/main/java/com/careerpirates/resumate/analysis/config/OpenAIProperties.java
+++ b/src/main/java/com/careerpirates/resumate/analysis/config/OpenAIProperties.java
@@ -1,23 +1,68 @@
 package com.careerpirates.resumate.analysis.config;
 
+import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-@Getter
+import java.util.ArrayList;
+import java.util.List;
+
 @Setter
 @Configuration
 @ConfigurationProperties(prefix = "openai")
 public class OpenAIProperties {
-    private String apiKey;
+
+    @Getter
+    private List<APIKey> apiKeys = new ArrayList<>();
+    @Getter
     private String baseUrl;
-    private Prompt prompt = new Prompt();
+    @Getter
+    private List<Prompt> prompts = new ArrayList<>();
+
+    private List<String> apiKey = new ArrayList<>();
+    private List<String> prompt = new ArrayList<>();
+
+    @Getter
+    @Setter
+    public static class APIKey {
+        private String key;
+        private Integer bucketSize;
+
+        public static APIKey fromString(String s) {
+            String[] parts = s.split(":");
+            APIKey key = new APIKey();
+            key.setKey(parts[0].trim());
+            key.setBucketSize(Integer.parseInt(parts[1].trim()));
+            return key;
+        }
+    }
 
     @Getter
     @Setter
     public static class Prompt {
         private String id;
         private String version;
+
+        public static Prompt fromString(String s) {
+            String[] parts = s.split(":");
+            Prompt p = new Prompt();
+            p.setId(parts[0].trim());
+            p.setVersion(parts[1].trim());
+            return p;
+        }
+    }
+
+    // 쉼표로 연결된 환경변수 → APIKey, Prompt 리스트로 변환
+    @PostConstruct
+    public void init() {
+        this.apiKeys = apiKey.stream()
+                .map(APIKey::fromString)
+                .toList();
+
+        this.prompts = prompt.stream()
+                .map(Prompt::fromString)
+                .toList();
     }
 }

--- a/src/main/java/com/careerpirates/resumate/analysis/config/OpenAIProperties.java
+++ b/src/main/java/com/careerpirates/resumate/analysis/config/OpenAIProperties.java
@@ -58,11 +58,22 @@ public class OpenAIProperties {
     @PostConstruct
     public void init() {
         this.apiKeys = apiKey.stream()
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
                 .map(APIKey::fromString)
                 .toList();
 
         this.prompts = prompt.stream()
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
                 .map(Prompt::fromString)
                 .toList();
+        
+        if (this.apiKeys.isEmpty() || this.prompts.isEmpty()) {
+            throw new IllegalStateException("OpenAI API 키와 프롬프트 환경변수를 설정하세요.");
+        }
+        if (this.apiKey.size() != this.prompts.size()) {
+            throw new IllegalStateException("OpenAI API 키와 프롬프트 환경변수 개수가 일치하지 않습니다.");
+        }
     }
 }

--- a/src/main/java/com/careerpirates/resumate/analysis/config/OpenAIRateLimiter.java
+++ b/src/main/java/com/careerpirates/resumate/analysis/config/OpenAIRateLimiter.java
@@ -2,19 +2,25 @@ package com.careerpirates.resumate.analysis.config;
 
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
-import org.springframework.stereotype.Component;
+import lombok.Getter;
 
 import java.time.Duration;
 
-@Component
 public class OpenAIRateLimiter {
 
+    @Getter
+    private final OpenAIProperties.APIKey apiKey;
+    @Getter
+    private final OpenAIProperties.Prompt prompt;
     private final Bucket bucket;
 
-    public OpenAIRateLimiter() {
+    public OpenAIRateLimiter(OpenAIProperties.APIKey apiKey, OpenAIProperties.Prompt prompt) {
+        this.apiKey = apiKey;
+        this.prompt = prompt;
+
         Bandwidth limit = Bandwidth.builder()
-                .capacity(5)
-                .refillIntervally(5, Duration.ofMinutes(1))
+                .capacity(apiKey.getBucketSize())
+                .refillIntervally(apiKey.getBucketSize(), Duration.ofMinutes(1))
                 .build();
 
         this.bucket = Bucket.builder().addLimit(limit).build();

--- a/src/main/java/com/careerpirates/resumate/analysis/worker/RedisWorker.java
+++ b/src/main/java/com/careerpirates/resumate/analysis/worker/RedisWorker.java
@@ -15,11 +15,10 @@ public class RedisWorker {
 
     private final OpenAIService openAIService;
     private final RedisQueue redisQueue;
-    private final OpenAIRateLimiter rateLimiter;
 
     @Async("workerExecutor")
     public void process(AnalysisRequestDto request) {
-        if (rateLimiter.canConsume()) {
+        if (openAIService.canConsume()) {
             log.info("큐에서 꺼낸 분석 요청 수행: { analysisId={} }", request.analysisId());
             openAIService.sendRequest(request.analysisId(), request.userInput());
         }
@@ -30,7 +29,7 @@ public class RedisWorker {
      */
     @Scheduled(fixedDelay = 5000)
     public void consume() {
-        while (!redisQueue.isQueueEmpty() && rateLimiter.canConsume()) {
+        while (!redisQueue.isQueueEmpty() && openAIService.canConsume()) {
             AnalysisRequestDto request = redisQueue.dequeue();
             if (request != null) {
                 process(request); // @Async 병렬 처리

--- a/src/main/java/com/careerpirates/resumate/analysis/worker/RedisWorker.java
+++ b/src/main/java/com/careerpirates/resumate/analysis/worker/RedisWorker.java
@@ -18,10 +18,8 @@ public class RedisWorker {
 
     @Async("workerExecutor")
     public void process(AnalysisRequestDto request) {
-        if (openAIService.canConsume()) {
-            log.info("큐에서 꺼낸 분석 요청 수행: { analysisId={} }", request.analysisId());
-            openAIService.sendRequest(request.analysisId(), request.userInput());
-        }
+        log.info("큐에서 꺼낸 분석 요청 수행: { analysisId={} }", request.analysisId());
+        openAIService.sendRequest(request.analysisId(), request.userInput());
     }
 
     /**

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -90,6 +90,4 @@ cookie:
 openai:
   api-key: ${OPENAI_API_KEY}
   base-url: https://api.openai.com/v1
-  prompt:
-    id: pmpt_68b69bf0c14081959f3bab045f17ccc803b70565310d26f7
-    version: 2
+  prompt: ${OPENAI_PROMPT}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -21,7 +21,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
         format_sql: true
@@ -91,6 +91,4 @@ cookie:
 openai:
   api-key: ${OPENAI_API_KEY}
   base-url: https://api.openai.com/v1
-  prompt:
-    id: pmpt_68b69bf0c14081959f3bab045f17ccc803b70565310d26f7
-    version: 2
+  prompt: ${OPENAI_PROMPT}

--- a/src/test/java/com/careerpirates/resumate/analysis/application/service/OpenAIServiceTest.java
+++ b/src/test/java/com/careerpirates/resumate/analysis/application/service/OpenAIServiceTest.java
@@ -29,8 +29,6 @@ class OpenAIServiceTest {
     private RedisQueue redisQueue;
 
     @MockitoBean
-    private OpenAIRateLimiter rateLimiter;
-    @MockitoBean
     private AnalysisService analysisService;
     @MockitoBean
     private WebClient webClient;
@@ -42,7 +40,6 @@ class OpenAIServiceTest {
         openAIService = new OpenAIService(
                 webClient,
                 properties,
-                rateLimiter,
                 eventPublisher,
                 redisQueue
         );
@@ -52,7 +49,7 @@ class OpenAIServiceTest {
     @DisplayName("OpenAI API 콜 제한에 도달하면 Redis 기반 큐에 요청을 넣습니다.")
     void sendRequest_tooManyRequests() {
         // given
-        while (rateLimiter.tryConsume()) { /* 소비해서 버킷 비우기 */ }
+        while (openAIService.tryConsumeLimiter() != null) { /* 소비해서 버킷 비우기 */ }
         Long analysisId = 1L;
 
         // when
@@ -61,6 +58,4 @@ class OpenAIServiceTest {
         // then
         assertThat(redisQueue.isQueueEmpty()).isFalse();
     }
-
-
 }


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #103

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
- OpenAI API 분당 토큰 제한에 따른 확장을 위해 멀티 계정 구조를 적용합니다.

## 📸스크린샷 (선택)

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
없음

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * 다중 OpenAI API 키/프롬프트 풀을 도입해 처리량과 안정성 향상.
  * 사용 불가 시 요청을 자동으로 대기열에 재등록하는 재시도 동작 추가.
* Refactor
  * 레이트리미터 풀과 선택 로직을 서비스 내부로 통합(서비스 단일 진입점에서 소비 제어).
  * 워커는 직접 제한 검사하지 않고 서비스의 소비 가능성만 확인하도록 변경.
* Chores
  * 프로덕션 SQL 로그 비활성화 및 프롬프트 설정을 환경변수 단일 값으로 단순화.
* Tests
  * 내부 소비 API에 맞춰 테스트 갱신.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->