### PR TITLE
[BUG] OpenAI API 응답 중 타임아웃으로 인한 문제 수정

### DIFF
--- a/src/main/java/com/careerpirates/resumate/global/config/SecurityConfig.java
+++ b/src/main/java/com/careerpirates/resumate/global/config/SecurityConfig.java
@@ -24,7 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class SecurityConfig {
 
 	private static final String[] AUTH_BYPASS_ENDPOINTS = {
-		"/v3/api-docs/**",
+		"/v3/api-docs**",
     	"/api-docs/**",
 		"/swagger-ui/**",
 		"/swagger-ui.html",

--- a/src/main/java/com/careerpirates/resumate/global/config/WebClientConfig.java
+++ b/src/main/java/com/careerpirates/resumate/global/config/WebClientConfig.java
@@ -22,7 +22,7 @@ public class WebClientConfig {
         // Netty 기반 HTTP client 설정
         HttpClient httpClient = HttpClient.create()
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000) // TCP 연결 타임아웃
-                .responseTimeout(Duration.ofMinutes(2))             // 응답 전체 타임아웃
+                .responseTimeout(Duration.ofMinutes(10))             // 응답 전체 타임아웃
                 .doOnConnected(conn -> conn
                         .addHandlerLast(new ReadTimeoutHandler(600, TimeUnit.SECONDS))   // 읽기 타임아웃
                         .addHandlerLast(new WriteTimeoutHandler(600, TimeUnit.SECONDS))  // 쓰기 타임아웃

--- a/src/main/java/com/careerpirates/resumate/global/config/WebClientConfig.java
+++ b/src/main/java/com/careerpirates/resumate/global/config/WebClientConfig.java
@@ -24,8 +24,8 @@ public class WebClientConfig {
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000) // TCP 연결 타임아웃
                 .responseTimeout(Duration.ofMinutes(2))             // 응답 전체 타임아웃
                 .doOnConnected(conn -> conn
-                        .addHandlerLast(new ReadTimeoutHandler(120, TimeUnit.SECONDS))   // 읽기 타임아웃
-                        .addHandlerLast(new WriteTimeoutHandler(120, TimeUnit.SECONDS))  // 쓰기 타임아웃
+                        .addHandlerLast(new ReadTimeoutHandler(600, TimeUnit.SECONDS))   // 읽기 타임아웃
+                        .addHandlerLast(new WriteTimeoutHandler(600, TimeUnit.SECONDS))  // 쓰기 타임아웃
                 );
 
         return WebClient.builder()


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #112

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
- 임시로 타임 아웃 시간을 10분으로 늘리겠습니다.

## 📸스크린샷 (선택)

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
없음

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API 문서 엔드포인트(/v3/api-docs) 인증 우회 범위를 확장하여 슬래시 유무 및 하위 경로에서 발생하던 간헐적 접근 실패를 해소했습니다. Swagger UI 등 연동 도구가 일관되게 동작합니다.

* **Chores**
  * 클라이언트 타임아웃 연장: 응답 대기시간을 2분에서 10분으로, 연결별 읽기/쓰기 타임아웃을 120초에서 600초로 늘려 대용량/장시간 처리 시 안정성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->