### PR TITLE
[REFACTOR] OpenAI API 요청 재시도 추가

### DIFF
--- a/src/main/java/com/careerpirates/resumate/analysis/application/service/OpenAIService.java
+++ b/src/main/java/com/careerpirates/resumate/analysis/application/service/OpenAIService.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.util.retry.Retry;
 
@@ -103,7 +104,9 @@ public class OpenAIService {
                                     }
 
                                     // 네트워크 계층 예외(연결 거부, 응답 타임아웃, 연결 닫힘 등): 재시도
-                                    return throwable instanceof IOException;
+                                    return throwable instanceof WebClientRequestException
+                                            || throwable instanceof IOException
+                                            || throwable.getCause() instanceof IOException;
                                 })
                 )
                 .onErrorContinue((throwable, obj) -> {

--- a/src/main/java/com/careerpirates/resumate/analysis/application/service/OpenAIService.java
+++ b/src/main/java/com/careerpirates/resumate/analysis/application/service/OpenAIService.java
@@ -13,7 +13,11 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.util.retry.Retry;
 
+import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -90,6 +94,18 @@ public class OpenAIService {
                 .doOnNext(response -> {
                     eventPublisher.publishEvent(new AnalysisCompletedEvent(analysisId, response));
                 })
+                .retryWhen(
+                        Retry.backoff(1, Duration.ofSeconds(2)) // 1번 재시도, 2초 뒤
+                                .filter(throwable -> {
+                                    if (throwable instanceof WebClientResponseException e) {
+                                        // 서버가 응답한 경우: 500대 상태 코드일 때 재시도
+                                        return e.getStatusCode().is5xxServerError();
+                                    }
+
+                                    // 네트워크 계층 예외(연결 거부, 응답 타임아웃, 연결 닫힘 등): 재시도
+                                    return throwable instanceof IOException;
+                                })
+                )
                 .onErrorContinue((throwable, obj) -> {
                     eventPublisher.publishEvent(new AnalysisErrorEvent(analysisId, throwable));
                 })


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #119

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
- OpenAI API 요청 실패시 2초 뒤 1회 재시도 로직을 추가합니다.
  Connection reset by peer 등 네트워크 오류에 대응하기 위함입니다.

## 📸스크린샷 (선택)

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
없음

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * OpenAI 연동 요청에 자동 재시도 정책을 도입했습니다. 서버(5xx) 오류나 네트워크/IO 장애 발생 시 2초 대기 후 한 번 재시도하여 일시적 실패를 완화합니다.
  * 기존 오류 보고 흐름은 유지되며, 분석 기능 이용 중 드물게 발생하던 실패와 응답 불안정성이 감소합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->